### PR TITLE
Version bump to v2.1.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM tiredofit/nginx-php-fpm:7.3
 LABEL maintainer="Dave Conroy (dave at tiredofit dot ca)"
 
 ### Set Defaults
-ENV LEANTIME_VERSION=v2.1.5 \
+ENV LEANTIME_VERSION=v2.1.6 \
     LEANTIME_REPO_URL=https://github.com/Leantime/leantime \
     NGINX_WEBROOT=/www/html \
     PHP_ENABLE_CREATE_SAMPLE_PHP=FALSE \


### PR DESCRIPTION
Another release for Leantime because of a hotfix. New installations do not work in 2.1.5

psetting error on installation #374