### PR TITLE
Bump to Leantime version 2.1.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM tiredofit/nginx-php-fpm:7.3
 LABEL maintainer="Dave Conroy (dave at tiredofit dot ca)"
 
 ### Set Defaults
-ENV LEANTIME_VERSION=v2.1.5 \
+ENV LEANTIME_VERSION=v2.1.7 \
     LEANTIME_REPO_URL=https://github.com/Leantime/leantime \
     NGINX_WEBROOT=/www/html \
     PHP_ENABLE_CREATE_SAMPLE_PHP=FALSE \


### PR DESCRIPTION
2.1.5 Dockerfile will create an image once installed, caused the attached error. The application will fail after the initial login page. Solution is to use leantime version 2.1.7

```
[19-Feb-2021 22:21:39 America/Los_Angeles] PHP Fatal error:  Uncaught PDOException: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'zp_projects.psettings' in 'field list' in /www/html/src/domain/projects/repositories/class.projects.php:357
Stack trace:
#0 /www/html/src/domain/projects/repositories/class.projects.php(357): PDOStatement->execute()
#1 /www/html/src/domain/projects/services/class.projects.php(33): leantime\domain\repositories\projects->getProject('3')
#2 /www/html/src/domain/projects/services/class.projects.php(379): leantime\domain\services\projects->getProject('3')
#3 /www/html/src/domain/projects/services/class.projects.php(339): leantime\domain\services\projects->changeCurrentSessionProject('3')
#4 /www/html/src/core/class.application.php(88): leantime\domain\services\projects->setCurrentProject()
#5 /www/html/public/index.php(41): leantime\core\application->start()
#6 {main}
  thrown in /www/html/src/domain/projects/repositories/class.projects.php on line 357
```