### PR TITLE
Fix for detecting new install

### DIFF
--- a/install/etc/cont-init.d/30-leantime
+++ b/install/etc/cont-init.d/30-leantime
@@ -20,7 +20,7 @@ ln -sf /www/logs/leantime "${NGINX_WEBROOT}"/resources/logs
 create_logrotate leantime /www/logs/leantime/error.log "${NGINX_USER}" "${NGINX_GROUP}"
 
 ### Check if New Install
-if [ ! -f "${NGINX_WEBROOT}"/server.php ]; then
+if [ ! -f "${NGINX_WEBROOT}"/public/index.php ]; then
     print_warn "Potential New Installation / Standalone Installation Detected - Copying Leantime Sourcecode"
     silent cp -a /assets/install/* "${NGINX_WEBROOT}"
 


### PR DESCRIPTION
The detection of a new install was for a non-existing file in the upstream code base. The auto update would therefore never work.