### PR TITLE
Set rewrite rules to upstream default and fix storage issues

### DIFF
--- a/install/etc/cont-init.d/30-leantime
+++ b/install/etc/cont-init.d/30-leantime
@@ -141,7 +141,7 @@ class config
     public \$userFilePath= "${STORAGE_FILE_PATH}/";
     public \$dbBackupPath = "${BACKUP_FILE_PATH}/";
 
-    public \$useS3 = ${s3_enabled,,};
+    public \$useS3 = "${s3_enabled,,}";
     public \$s3Key = "${S3_KEY}";
     public \$s3Secret = "${S3_SECRET}";
     public \$s3Bucket = "${S3_BUCKET}";

--- a/install/etc/cont-init.d/30-leantime
+++ b/install/etc/cont-init.d/30-leantime
@@ -26,11 +26,11 @@ if [ ! -f "${NGINX_WEBROOT}"/public/index.php ]; then
 
     ### If running with /www/html or NGINX_WEBROOT mapped, then create persistent storage
     ### Storage redirection
+    s3_enabled="false"
     if [ -d "/data" ]; then
         print_warn "Detected /data directory. Persistently saving settings and volatile information"
         case "${STORAGE_TYPE,,}" in
             files* | local )
-                s3_enabled="false"
                 rm -rf "${NGINX_WEBROOT}"/public/userfiles
                 mkdir -p "${NGINX_WEBROOT}"/public/
                 ln -sf /data/userfiles "${NGINX_WEBROOT}"/public/userfiles
@@ -141,7 +141,7 @@ class config
     public \$userFilePath= "${STORAGE_FILE_PATH}/";
     public \$dbBackupPath = "${BACKUP_FILE_PATH}/";
 
-    public \$useS3 = "${s3_enabled,,}";
+    public \$useS3 = ${s3_enabled,,};
     public \$s3Key = "${S3_KEY}";
     public \$s3Secret = "${S3_SECRET}";
     public \$s3Bucket = "${S3_BUCKET}";

--- a/install/etc/cont-init.d/30-leantime
+++ b/install/etc/cont-init.d/30-leantime
@@ -33,8 +33,9 @@ if [ ! -f "${NGINX_WEBROOT}"/public/index.php ]; then
             files* | local )
                 rm -rf "${NGINX_WEBROOT}"/public/userfiles
                 mkdir -p "${NGINX_WEBROOT}"/public/
-                ln -sf /data/userfiles "${NGINX_WEBROOT}"/public/userfiles
                 mkdir -p /data/storage
+                mkdir -p /data/public
+                ln -sf /data/public "${NGINX_WEBROOT}"/public/userfiles
                 rm -rf "${NGINX_WEBROOT}"/"${STORAGE_FILE_PATH}"
                 ln -sf /data/storage "${NGINX_WEBROOT}"/"${STORAGE_FILE_PATH}"
                 ln -sf /data/config "${NGINX_WEBROOT}"/config/configuration.php

--- a/install/etc/cont-init.d/30-leantime
+++ b/install/etc/cont-init.d/30-leantime
@@ -4,6 +4,8 @@ source /assets/functions/00-container
 prepare_service
 PROCESS_NAME="leantime"
 
+s3_enabled="false"
+
 check_service_initialized init 20-php-fpm
 
 ### Sanity Test
@@ -26,7 +28,6 @@ if [ ! -f "${NGINX_WEBROOT}"/public/index.php ]; then
 
     ### If running with /www/html or NGINX_WEBROOT mapped, then create persistent storage
     ### Storage redirection
-    s3_enabled="false"
     if [ -d "/data" ]; then
         print_warn "Detected /data directory. Persistently saving settings and volatile information"
         case "${STORAGE_TYPE,,}" in

--- a/install/etc/nginx/sites.available/leantime.conf
+++ b/install/etc/nginx/sites.available/leantime.conf
@@ -13,39 +13,14 @@ server {
     	include fastcgi_params;
   }
 
-location / {
-      rewrite ^/?$ /index.php?act=dashboard.show;
-      rewrite ^/([^/\.]+)/([^/\.]+)/?$ /index.php?act=$1.$2;
-      rewrite ^/([^/\.]+)/([^/\.]+)/([^/\.]+)/?$ /index.php?act=$1.$2&id=$3;
-}
+ location / {
 
-location = /resetPassword {
-      rewrite ^(.*)$ /index.php?resetPassword=true;
-}
+    rewrite ^/?$ /index.php?act=dashboard.show;
+    rewrite ^/([^/\.]+)/?$ /index.php?act=$1;
+    rewrite ^/([^/\.]+)/([^/\.]+)/?$ /index.php?act=$1.$2;
+    rewrite ^/([^/\.]+)/([^/\.]+)/([^/\.]+)/?$ /index.php?act=$1.$2&id=$3;
+  }
 
-location /resetPassword {
-      rewrite ^/resetPassword/([^/\.]+)/?$ /index.php?resetPassword=true&hash=$1;
-}
-
-location = /install {
-      rewrite ^(.*)$ /index.php?install=true;
-}
-
-location = /logout {
-      rewrite ^(.*)$ /index.php?logout=1;
-}
-
-location /install {
-      rewrite ^/install/([^/\.]+)/?$ /index.php?install=true;
-}
-
-location = /update {
-      rewrite ^(.*)$ /index.php?update=true;
-}
-
-location /update {
-      rewrite ^/update/([^/\.]+)/?$ /index.php?update=true;
-}
 
 # additional config
 


### PR DESCRIPTION
This is my fix for #9 
There was some looping going on.
I changed all rewrites for nginx to the upstream example which was updated some time  ago.
Works for me.

2nd fix is for not using the local file storage due to an uninitialized s3_enabled when testing to use S3 storage,
I guess it us php or due to the function that tests for true/false, I have very little php experience. But testing for a not existing variable resulted in it being evaluated to TRUE. Call me surprised.  I undid my earlier fix which was more cosmic. 

3rd fix for a not working symlink for public userfiles which is used to store the logo. I made a change to create a public folder and not use the existing storage for non-public userfiles. Otherwise you could hypothetically brute-force/fuzz for files files stored there without logging in. I have not yet grasped your other changes for the whole storage of either userfiles or all data, so it might break something else...

Also it is not my intention to have multiple fixes in one pull request. That is me being not proficient in git and github.