### PR TITLE
adjust for leantime 2.4 config

### DIFF
--- a/install/etc/cont-init.d/30-leantime
+++ b/install/etc/cont-init.d/30-leantime
@@ -118,9 +118,17 @@ if [ "${SETUP_TYPE,,}" = "auto" ]; then
 
     cat <<EOF > "${NGINX_WEBROOT}"/config/configuration.php
 <?php
-namespace leantime\core;
 
-class config
+namespace Leantime\Config;
+
+/***
+ *
+ * Config class
+ * This class is included for backwards compatibility and to be used with subfolder installations
+ *
+ * @see config/sample.env
+ */
+class Config
 {
     /* General */
     public \$sitename = "${SITE_NAME}";


### PR DESCRIPTION
When accessing leantime 2.4 an error appears due to a breaking change described here: [https://github.com/leantime/leantime/releases/tag/v2.4-beta-2](https://github.com/leantime/leantime/releases/tag/v2.4-beta-2
)

This adopts the change 